### PR TITLE
feat: batch persistence (#2) and reorg handling (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `root_hash()` now takes `&mut self` (breaking API change in ubt crate)
 - Streaming root verification at startup (#6) - uses StreamingTreeBuilder for memory-efficient verification
 - MDBX-backed read path (#5) - overlay-aware getters for proof generation without full tree
+- Batch persistence across blocks (#2) - MDBX writes batched by `UBT_FLUSH_INTERVAL` env var
+  - Default interval=1 maintains current behavior
+  - Higher values reduce I/O when same stems modified across consecutive blocks
+
+### Fixed
+- Proper reorg handling with per-block deltas (#3)
+  - Stores old values before applying state changes
+  - Reverts apply deltas in LIFO order (newest block first, within-block reversed)
+  - Deltas for persisted blocks preserved for crash recovery
 
 ### Added
 - `iter_entries_sorted()` for streaming MDBX iteration
@@ -23,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - State extraction from `BundleState` (accounts, storage, code)
 
 ### Known Issues
-- Reorgs not properly handled (#3)
 - Full tree still loaded into memory at startup (streaming is verification only)
 
 ## [0.1.0] - 2024-12-08


### PR DESCRIPTION
## Summary
Implements issues #2 (Batch Persistence) and #3 (Reorg Handling).

## #2 Batch Persistence Across Blocks

### Changes
- Added `UBT_FLUSH_INTERVAL` env var to control flush frequency (default=1)
- Track `last_persisted_block` and `last_persisted_hash` separately from current head
- `commit()` only flushes to MDBX when `(block_number - last_persisted_block) >= flush_interval`
- `get_head()` returns persisted head for proper ExEx recovery

### Impact
- Default behavior unchanged (FLUSH_INTERVAL=1)
- Higher values reduce MDBX I/O when same stems modified across consecutive blocks
- On crash: lose up to FLUSH_INTERVAL-1 blocks, recovered via ExEx replay

## #3 Reorg Handling with Per-Block Deltas

### Changes
- Added `ubt_block_deltas` MDBX table storing `(stem, subindex, old_value)` per block
- `commit()` captures old values before applying changes
- `revert()` applies deltas in LIFO order (reverse block order, reverse within-block order)
- Deltas for persisted blocks preserved for crash recovery

### Oracle Review Fixes
1. **Reverse per-block deltas**: Multi-write per key in same block now correctly restores pre-block value
2. **Conditional delta deletion**: Only delete deltas for `block_number > last_persisted_block` to survive crash+restart scenarios

## Testing
- Code compiles successfully
- Oracle reviewed both features and identified/fixed two correctness issues

## Checklist
- [x] Code follows project conventions
- [x] CHANGELOG updated
- [x] Oracle review completed

Closes #2
Closes #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds flush-interval batching to MDBX persistence and introduces per-block deltas for accurate reorgs, updating head handling and database schema.
> 
> - **ExEx / Persistence**:
>   - Batch flush control via `UBT_FLUSH_INTERVAL`; persist stems/head only when interval elapses.
>   - Track `last_persisted_block/hash`; `get_head()` now returns persisted head.
> - **Reorg Handling**:
>   - Capture `(stem, subindex, old_value)` deltas in `commit()`; apply in reverse order in `revert()`.
>   - Delete deltas only for blocks beyond the persisted head.
> - **MDBX Schema & APIs**:
>   - New table `ubt_block_deltas`; add `save_block_deltas`, `load_block_deltas`, `delete_block_deltas`, `delete_deltas_after`.
> - **Changelog**:
>   - Document batch persistence and reorg handling under Unreleased; remove outdated known issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8db460531035379ecfc067d5ea07262a326281a8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable flush-based batch persistence with adjustable interval (defaults preserve prior behavior).
  * Per-block delta persistence, replay, and backfill support to enable streaming iteration and state extraction.

* **Performance**
  * Batch persistence reduces database write overhead and deferred root-hash computation reduces redundant work.

* **Bug Fixes**
  * Corrected reorg handling with crash-safe per-block delta recovery; Known Issues updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->