### PR TITLE
feat: MDBX-backed read path for proofs (#5)

### DIFF
--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -70,7 +70,6 @@ impl UbtDatabase {
         Ok(())
     }
 
-    #[allow(dead_code)]
     pub fn load_stem(&self, stem: &Stem) -> eyre::Result<Option<StemNode>> {
         let txn = self.env.begin_ro_txn()?;
         let stems_db = txn.open_db(Some(STEMS_DB))?;

--- a/src/ubt_exex.rs
+++ b/src/ubt_exex.rs
@@ -184,6 +184,25 @@ impl UbtExEx {
         warn!("UBT revert requested - full rebuild required for accurate state");
         Ok(())
     }
+
+    /// Get a stem node, checking dirty overlay first, then MDBX.
+    /// Used for proof generation without requiring full tree in memory.
+    pub fn get_stem(&self, stem: &Stem) -> eyre::Result<Option<StemNode>> {
+        if let Some(node) = self.dirty_stems.get(stem) {
+            return Ok(Some(node.clone()));
+        }
+        self.db.load_stem(stem)
+    }
+
+    /// Get a specific value by TreeKey, checking overlay then MDBX.
+    pub fn get_value(&self, key: &TreeKey) -> eyre::Result<Option<B256>> {
+        if let Some(node) = self.dirty_stems.get(&key.stem) {
+            if let Some(value) = node.get_value(key.subindex) {
+                return Ok(Some(value));
+            }
+        }
+        Ok(self.tree.get(key))
+    }
 }
 
 /// Verify root hash using streaming computation (memory-efficient).


### PR DESCRIPTION
## Summary
Implements issue #5 - MDBX-backed read path for proof generation.

## Changes
- Removed `#[allow(dead_code)]` from `load_stem` in persistence.rs
- Added `get_stem()` - overlay-aware stem getter (dirty_stems -> MDBX)
- Added `get_value()` - overlay-aware value getter (dirty_stems -> tree)

## Impact
- Enables proof generation without requiring full tree in memory
- Queries check dirty overlay first, then fall back to persisted data
- Foundation for future fully MDBX-backed design

Closes #5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `get_stem` and `get_value` that read from dirty overlay then MDBX/tree; enable `load_stem` by removing dead-code allow.
> 
> - **UBT ExEx**:
>   - Add `get_stem(stem)` to fetch stem from `dirty_stems` overlay, fallback to MDBX via `db.load_stem`.
>   - Add `get_value(key)` to fetch value from overlay, fallback to in-memory `tree`.
> - **Persistence**:
>   - Remove `#[allow(dead_code)]` from `load_stem`, enabling MDBX-backed stem reads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ceb091b6d29a6605d2b3cd9d2c9926a7b0e8680. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced data access with overlay storage prioritization and fallback to persistent storage, improving efficiency for proof generation operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->